### PR TITLE
ci: enable workflow on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: MERN CI/CD Pipeline
 
 on:
   pull_request:
+  push:
     branches:
       - main
 
@@ -16,7 +17,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24.13.0"
+          node-version: "20"
       - name: Install root dependencies
         run: npm ci
       - name: Run Lint


### PR DESCRIPTION
## Summary

Update CI workflow to trigger on both pull requests and pushes to the main branch.  
This ensures status checks are properly registered for branch protection rules.

Additionally, minor improvements were made to stabilize the pipeline execution.

- Added `push: main` trigger to workflow
- Ensured workflow runs on PR and after merge to main
---

## Checklist (must complete before merge)

- [x] Work is on a short-lived branch
- [x] PR opened early (not only at completion)
- [x] At least 1 teammate review requested
- [ ] CI checks pass
- [ ] Docker runs successfully:
  - `cp .env.example .env`
  - `docker compose up --build`
- [ ] Lint and format pass:
  - `npm run lint`
  - `npm run format`
- [ ] README or docs updated if behavior/setup changed
- [ ] No secrets (.env, API keys, credentials) committed